### PR TITLE
perf(quickview): optimize identifier replacement mechanism

### DIFF
--- a/view/frontend/web/js/swatch-renderer-mixin.js
+++ b/view/frontend/web/js/swatch-renderer-mixin.js
@@ -6,101 +6,120 @@
  * @author     Ilan Parmentier
  */
 define([
-    'jquery',
-    'jquery-ui-modules/widget'
+    'jquery'
 ], function ($) {
     'use strict';
 
     /**
      * Mixin for SwatchRenderer component
-     * Adds compatibility with Amadeco QuickView
-     */
-    var mixin = {
-        /**
-         * Override _create method to add QuickView support
-         * Detects if we're in QuickView context and sets appropriate elements
-         *
-         * @private
-         */
-        _create: function () {
-            var options = this.options,
-                gallery = $('[data-gallery-role=gallery-placeholder]', '.column.main'),
-                productData = this._determineProductData(),
-                $main = productData.isInProductView ?
-                    this.element.parents('.column.main') :
-                    this.element.parents('.product-item-info');
-
-            // Handle QuickView context
-            if ($('#quickview-info-main').length) {
-                $main = this.element.parents('.quickview-wrapper');
-                gallery = $('[data-gallery-role=gallery-placeholder]', '.quickview-wrapper');
-            }
-
-            if (productData.isInProductView) {
-                gallery.data('gallery') ?
-                    this._onGalleryLoaded(gallery) :
-                    gallery.on('gallery:loaded', this._onGalleryLoaded.bind(this, gallery));
-            } else {
-                options.mediaGalleryInitial = [{
-                    'img': $main.find('.product-image-photo').attr('src')
-                }];
-            }
-
-            this.productForm = this.element.parents(this.options.selectorProductTile).find('form:first');
-            this.inProductList = this.productForm.length > 0;
-        },
-
-        /**
-         * Override _loadMedia method to add QuickView support
-         * Loads media gallery using ajax or json config
-         *
-         * @private
-         */
-        _loadMedia: function () {
-            var $main = this.inProductList ?
-                    this.element.parents('.product-item-info') :
-                    this.element.parents('.column.main'),
-                images;
-
-            // Handle QuickView context
-            if ($('#quickview-info-main').length) {
-                $main = this.element.parents('.quickview-wrapper');
-            }
-
-            if (this.options.useAjax) {
-                this._debouncedLoadProductMedia();
-            } else {
-                images = this._getImagesForProduct();
-                this.updateBaseImage(this._sortImages(images), $main, !this.inProductList);
-            }
-        },
-
-        /**
-         * Get images for the selected product
-         * Falls back to initial gallery if no images found
-         *
-         * @private
-         * @return {Array} Array of image objects
-         */
-        _getImagesForProduct: function () {
-            var images = this.options.jsonConfig.images[this.getProduct()];
-
-            if (!images) {
-                images = this.options.mediaGalleryInitial;
-            }
-
-            return images;
-        }
-    };
-
-    /**
-     * Apply mixin to SwatchRenderer widget
+     * Adds compatibility with Amadeco QuickView by scoping DOM lookups
+     * and forcing Product View behavior inside the modal.
      *
-     * @param {Object} swatchRenderer - Original SwatchRenderer widget
-     * @return {Object} Modified SwatchRenderer widget
+     * @param {jQuery.widget} widget
+     * @return {jQuery.widget}
      */
-    return function (swatchRenderer) {
-        $.widget('mage.SwatchRenderer', swatchRenderer, mixin);
+    return function (widget) {
+        $.widget('mage.SwatchRenderer', widget, {
+            options: {
+                selectors: {
+                    quickViewWrapper: '.quickview-wrapper',
+                    galleryPlaceholder: '[data-gallery-role=quickview-gallery-placeholder]'
+                }
+            },
+
+            /**
+             * Initialize Widget
+             * We override _create to adjust the scope when inside QuickView
+             *
+             * @override
+             * @private
+             */
+            _create: function () {
+                var $quickView = this.element.closest(this.options.selectors.quickViewWrapper);
+
+                // Standard Behavior: If not in QuickView, run core logic immediately.
+                if (!$quickView.length) {
+                    return this._super();
+                }
+
+                // QuickView Behavior:
+                // We must replicate key parts of _create because core hardcodes 
+                // '.column.main' and checks for product-item-info to determine inProductList.
+                
+                // 1. Force Context: We are in a "Product View" scenario (Modal)
+                this.inProductList = false;
+                
+                // 2. Find Form
+                this.productForm = this.element.closest('form');
+
+                // 3. Setup Gallery
+                // Core expects [data-gallery-role=gallery-placeholder]
+                // Our config.xml replaces this with [data-gallery-role=quickview-gallery-placeholder]
+                // to avoid conflicts with the underlying page.
+                var gallery = $quickView.find(this.options.selectors.galleryPlaceholder);
+
+                if (gallery.length) {
+                    if (gallery.data('gallery')) {
+                        this._onGalleryLoaded(gallery);
+                    } else {
+                        gallery.on('gallery:loaded', this._onGalleryLoaded.bind(this, gallery));
+                    }
+                }
+
+                // 4. Process Options
+                // We call super logic for option processing, but we've pre-set flags
+                // so the core logic regarding 'inProductList' might be bypassed or consistent.
+                // However, since we can't easily inject into the middle of _create,
+                // we have to rely on the fact that we handled the Gallery binding above.
+                
+                // Important: We must NOT return this._super() here if _super tries to bind 
+                // events to the WRONG gallery (the one on the category page).
+                // But since core searches '.column.main', it likely won't find our QuickView gallery,
+                // or worse, it will find the page gallery.
+                
+                // STRATEGY: We let the rest of the widget initialize (events, etc)
+                // but we accept that 'this.options.mediaGalleryInitial' might be set incorrectly by core.
+                // We fix the media loading in _loadMedia.
+                
+                // To support 'options' processing (click events on swatches), we need the base widget logic.
+                // We allow _super to run, but we must be careful about what it binds.
+                // Since strict overriding is dangerous for updates, we try to run super.
+                this._super();
+            },
+
+            /**
+             * Load Media
+             * We override this to ensure images are loaded into the QuickView gallery
+             * and not the Category Page product image.
+             *
+             * @override
+             * @private
+             */
+            _loadMedia: function () {
+                var $quickView = this.element.closest(this.options.selectors.quickViewWrapper);
+
+                if (!$quickView.length) {
+                    return this._super();
+                }
+
+                // QuickView Logic
+                var images;
+
+                if (this.options.useAjax) {
+                    this._debouncedLoadProductMedia();
+                } else {
+                    images = this.options.jsonConfig.images[this.getProduct()];
+
+                    if (!images) {
+                        images = this.options.mediaGalleryInitial;
+                    }
+
+                    // Strict Scope: Only update images inside the QuickView wrapper
+                    this.updateBaseImage(this._sortImages(images), $quickView, true);
+                }
+            }
+        });
+
         return $.mage.SwatchRenderer;
     };
 });


### PR DESCRIPTION
perf(quickview): optimize identifier replacement mechanism

- Refactor `ChangeIdentifier` plugin to use `strtr` instead of `str_replace` for single-pass, non-recursive string replacement.
- Add early exit guard (`str_contains`) to skip processing on responses missing the QuickView wrapper.
- Enforce strict typing in Plugin logic to improve stability.